### PR TITLE
Fixing jar filename in config file

### DIFF
--- a/scripts/run/config.sh
+++ b/scripts/run/config.sh
@@ -55,7 +55,7 @@ export ENTRADA_LOG_DIR="/var/log/entrada"
 export NAMESERVERS=""
 
 #java
-export ENTRADA_JAR="entrada-0.0.2-jar-with-dependencies.jar"
+export ENTRADA_JAR="pcap-to-parquet-0.0.2-jar-with-dependencies.jar"
 
 #security if Kerberos is enabled, otherwise keep empty
 export KRB_USER=""


### PR DESCRIPTION
In file `$ENTRADA_HOME/scripts/run/config.sh` the variable `ENTRADA_JAR` is set to `“entrada-0.0.2-jar-with-dependencies.jar”`, but the correct name for the JAR file is `"pcap-to-parquet-0.0.2-jar-with-dependencies.jar"`.
