### PR TITLE
Capture script fix

### DIFF
--- a/scripts/capture/capture.sh
+++ b/scripts/capture/capture.sh
@@ -29,4 +29,4 @@ HOST_V6=
 HOSTNAME_PREFIX=
 
 #use  & 0x1fff != 0 to also capture fragmented packets
-tcpdump -i eth1 -w ${DUMPDIR}/$HOSTNAME_PREFIX_%Y-%m-%d_%H:%M.pcap.gz -G 300 -z gzip '(( port 53 or ip[6:2] & 0x1fff != 0) or icmp or icmp6 ) and ( host $HOST_V4 or host $HOST_V6 )' 
+tcpdump -i eth1 -w ${DUMPDIR}/$HOSTNAME_PREFIX_%Y-%m-%d_%H:%M.pcap -G 300 -z gzip '(( port 53 or ip[6:2] & 0x1fff != 0) or icmp or icmp6 ) and ( host $HOST_V4 or host $HOST_V6 )' 

--- a/scripts/capture/capture.sh
+++ b/scripts/capture/capture.sh
@@ -29,4 +29,4 @@ HOST_V6=
 HOSTNAME_PREFIX=
 
 #use  & 0x1fff != 0 to also capture fragmented packets
-tcpdump -i eth1 -w ${DUMPDIR}/$HOSTNAME_PREFIX_%Y-%m-%d_%H:%M.pcap -G 300 -z gzip '(( port 53 or ip[6:2] & 0x1fff != 0) or icmp or icmp6 ) and ( host $HOST_V4 or host $HOST_V6 )' 
+tcpdump -i eth1 -w ${DUMPDIR}/$HOSTNAME_PREFIX_%Y-%m-%d_%H:%M.pcap -G 300 -z gzip "(( port 53 or ip[6:2] & 0x1fff != 0) or icmp or icmp6 ) and ( host $HOST_V4 or host $HOST_V6 )"


### PR DESCRIPTION
The ‘.gz’ file extension is not needed in the `tcpdump` command: Gzip will automatically add that when compressing the plain ‘.pcap’ file.

The `tcpdump` filter should be wrapped with double quotes. With single quotes bash can’t evaluate variables inside the filter specification (at least this happens with my bash, version 4.3.42).
