### PR TITLE
config.sh: autodetect NAMESERVERS

### DIFF
--- a/scripts/run/config.sh
+++ b/scripts/run/config.sh
@@ -52,7 +52,7 @@ export PCAP_DAYS_TO_KEEP=10
 export ENTRADA_LOG_DIR="/var/log/entrada"
 
 #name servers, seperate multiple NS with a colon ;
-export NAMESERVERS=""
+export NAMESERVERS=`cd ${DATA_RSYNC_DIR}; ls -dm */ | tr '\n' ' ' |  tr ',' ';' | sed 's/[\/ ]//g'`
 
 #java
 export ENTRADA_JAR="pcap-to-parquet-0.0.3-jar-with-dependencies.jar"


### PR DESCRIPTION
This patch checks the directories in DATA_RSYNC_DIR and adds them as list to the NAMESERVERS-variable in config.sh