### PR TITLE
store server location

### DIFF
--- a/pcap-to-parquet/pom.xml
+++ b/pcap-to-parquet/pom.xml
@@ -67,6 +67,12 @@
 		</dependency>
 
 		<dependency>
+			  <groupId>org.apache.commons</groupId>
+	  		  <artifactId>commons-lang3</artifactId>
+			  <version>3.4</version>
+		</dependency>
+
+		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 			<version>11.0.2</version>

--- a/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/DNSParquetPacketWriter.java
+++ b/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/DNSParquetPacketWriter.java
@@ -159,8 +159,10 @@ public class DNSParquetPacketWriter extends AbstractParquetPacketWriter {
 		String svr = combo.getServer();
 		if (svr.contains("_")) {
 			String[] parts = svr.split("_"); 
-			builder.set("anycast_server", parts[0]);
-			builder.set("anycast_location", parts[1]);
+			builder.set("server_ns_name", parts[0]);
+			builder.set("server_location", parts[1]);
+		} else {
+			builder.set("server_ns_name", combo.getServer());
 		}
 		
 		//add meta data

--- a/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/DNSParquetPacketWriter.java
+++ b/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/DNSParquetPacketWriter.java
@@ -154,6 +154,14 @@ public class DNSParquetPacketWriter extends AbstractParquetPacketWriter {
 
 		//set the nameserver the queries are going to/coming from
 		builder.set("svr", combo.getServer());
+
+		//check if _ in server name. If yes split the name and use 2nd part as anycast location
+		String svr = combo.getServer();
+		if (svr.contains("_")) {
+			String[] parts = svr.split("_"); 
+			builder.set("anycast_server", parts[0]);
+			builder.set("anycast_location", parts[1]);
+		}
 		
 		//add meta data
 		enrich(reqTransport, respTransport, builder);

--- a/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/ICMPParquetPacketWriter.java
+++ b/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/ICMPParquetPacketWriter.java
@@ -123,6 +123,16 @@ public class ICMPParquetPacketWriter extends AbstractParquetPacketWriter {
 		    .set("l4_srcp",  icmpPacket.getSrcPort())
 		    .set("l4_dstp",  icmpPacket.getDstPort())
 		    .set("ip_len",  icmpPacket.getTotalLength()); //size of ip packet incl headers
+
+
+                //check if _ in server name. If yes split the name and use 2nd part as anycast location
+                String svr = packetCombo.getServer();
+                if (svr.contains("_")) {
+                        String[] parts = svr.split("_");
+                        builder.set("anycast_server", parts[0]);
+                        builder.set("anycast_location", parts[1]);
+                }
+
 	    	//orig packet from payload
 		 
 	    if(originalPacket != null && originalPacket != Packet.NULL){

--- a/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/ICMPParquetPacketWriter.java
+++ b/pcap-to-parquet/src/main/java/nl/sidn/pcap/parquet/ICMPParquetPacketWriter.java
@@ -129,9 +129,11 @@ public class ICMPParquetPacketWriter extends AbstractParquetPacketWriter {
                 String svr = packetCombo.getServer();
                 if (svr.contains("_")) {
                         String[] parts = svr.split("_");
-                        builder.set("anycast_server", parts[0]);
-                        builder.set("anycast_location", parts[1]);
-                }
+                        builder.set("server_ns_name", parts[0]);
+                        builder.set("server_location", parts[1]);
+                } else {
+	    		builder.set("server_ns_name", packetCombo.getServer());
+		}
 
 	    	//orig packet from payload
 		 

--- a/pcap-to-parquet/src/main/resources/dns-query.avsc
+++ b/pcap-to-parquet/src/main/resources/dns-query.avsc
@@ -57,6 +57,8 @@
     { "name": "proc_time", "type": ["null","int"], "default": null },
     { "name": "is_google", "type": "boolean", "default": false},
     { "name": "is_opendns", "type": "boolean", "default": false},
-    { "name": "dns_res_len", "type": ["null","int"], "default": null}
+    { "name": "dns_res_len", "type": ["null","int"], "default": null},
+    { "name": "anycast_server", "type": ["null","string"], "default": null },
+    { "name": "anycast_location", "type": ["null","string"], "default": null }
   ]
 }

--- a/pcap-to-parquet/src/main/resources/dns-query.avsc
+++ b/pcap-to-parquet/src/main/resources/dns-query.avsc
@@ -58,7 +58,7 @@
     { "name": "is_google", "type": "boolean", "default": false},
     { "name": "is_opendns", "type": "boolean", "default": false},
     { "name": "dns_res_len", "type": ["null","int"], "default": null},
-    { "name": "anycast_server", "type": ["null","string"], "default": null },
-    { "name": "anycast_location", "type": ["null","string"], "default": null }
+    { "name": "server_ns_name", "type": ["null","string"], "default": null },
+    { "name": "server_location", "type": ["null","string"], "default": null }
   ]
 }

--- a/pcap-to-parquet/src/main/resources/icmp-packet.avsc
+++ b/pcap-to-parquet/src/main/resources/icmp-packet.avsc
@@ -56,7 +56,7 @@
     { "name": "orig_dns_labels", "type": ["null","int"], "default": null},
     { "name": "svr", "type": "string" },
     { "name": "time_micro", "type": "long" },
-    { "name": "anycast_server", "type": ["null","string"], "default": null },
-    { "name": "anycast_location", "type": ["null","string"], "default": null }
+    { "name": "server_ns_name", "type": ["null","string"], "default": null },
+    { "name": "server_location", "type": ["null","string"], "default": null }
   ]
 }

--- a/pcap-to-parquet/src/main/resources/icmp-packet.avsc
+++ b/pcap-to-parquet/src/main/resources/icmp-packet.avsc
@@ -55,6 +55,8 @@
     { "name": "orig_dns_edns_do", "type": ["null","boolean"], "default": null},
     { "name": "orig_dns_labels", "type": ["null","int"], "default": null},
     { "name": "svr", "type": "string" },
-    { "name": "time_micro", "type": "long" }
+    { "name": "time_micro", "type": "long" },
+    { "name": "anycast_server", "type": ["null","string"], "default": null },
+    { "name": "anycast_location", "type": ["null","string"], "default": null }
   ]
 }

--- a/scripts/database/create-table-dns-queries.sql
+++ b/scripts/database/create-table-dns-queries.sql
@@ -55,8 +55,8 @@ create external table if not exists queries (
  is_google boolean,
  is_opendns boolean,
  dns_res_len INT,
- anycast_server STRING,
- anycast_location STRING
+ server_ns_name STRING,
+ server_location STRING
 ) 
  partitioned by (year INT, month INT, day INT, server string)
   STORED AS PARQUETFILE

--- a/scripts/database/create-table-dns-queries.sql
+++ b/scripts/database/create-table-dns-queries.sql
@@ -54,7 +54,10 @@ create external table if not exists queries (
  proc_time INT,
  is_google boolean,
  is_opendns boolean,
- dns_res_len INT)
+ dns_res_len INT,
+ anycast_server STRING,
+ anycast_location STRING
+) 
  partitioned by (year INT, month INT, day INT, server string)
   STORED AS PARQUETFILE
   LOCATION '_HDFS_LOCATION_queries';

--- a/scripts/database/create-table-dns-staging.sql
+++ b/scripts/database/create-table-dns-staging.sql
@@ -55,7 +55,9 @@ create external table if not exists dns.staging (
  proc_time INT,
  is_google boolean,
  is_opendns boolean,
- dns_res_len INT)
+ dns_res_len INT,
+ anycast_server string,
+ anycast_location string )
  partitioned by (year INT, month INT, day INT, server string)
   STORED AS PARQUETFILE
   LOCATION '_HDFS_LOCATION_staging';

--- a/scripts/database/create-table-dns-staging.sql
+++ b/scripts/database/create-table-dns-staging.sql
@@ -56,8 +56,8 @@ create external table if not exists dns.staging (
  is_google boolean,
  is_opendns boolean,
  dns_res_len INT,
- anycast_server string,
- anycast_location string )
+ server_ns_name string,
+ server_location string )
  partitioned by (year INT, month INT, day INT, server string)
   STORED AS PARQUETFILE
   LOCATION '_HDFS_LOCATION_staging';

--- a/scripts/database/create-table-icmp-packets.sql
+++ b/scripts/database/create-table-icmp-packets.sql
@@ -53,8 +53,8 @@ orig_dns_edns_do BOOLEAN,
 orig_dns_labels INT,
 svr string,
 time_micro bigint,
-anycast_server string,
-anycast_location string)
+server_ns_name string,
+server_location string)
 partitioned by (year smallint, month smallint, day smallint)
   STORED AS PARQUETFILE
   LOCATION '_HDFS_LOCATION_icmp';

--- a/scripts/database/create-table-icmp-packets.sql
+++ b/scripts/database/create-table-icmp-packets.sql
@@ -52,7 +52,9 @@ orig_dns_edns_version SMALLINT,
 orig_dns_edns_do BOOLEAN,
 orig_dns_labels INT,
 svr string,
-time_micro bigint)
+time_micro bigint,
+anycast_server string,
+anycast_location string)
 partitioned by (year smallint, month smallint, day smallint)
   STORED AS PARQUETFILE
   LOCATION '_HDFS_LOCATION_icmp';

--- a/scripts/database/create-table-icmp-staging.sql
+++ b/scripts/database/create-table-icmp-staging.sql
@@ -53,7 +53,9 @@ orig_dns_edns_version SMALLINT,
 orig_dns_edns_do BOOLEAN,
 orig_dns_labels INT,
 svr string,
-time_micro bigint)
+time_micro bigint,
+anycast_server string,
+anycast_location string)
  partitioned by (year smallint, month smallint, day smallint)
   STORED AS PARQUETFILE
   LOCATION '_HDFS_LOCATION_icmp-staging';

--- a/scripts/database/create-table-icmp-staging.sql
+++ b/scripts/database/create-table-icmp-staging.sql
@@ -54,8 +54,8 @@ orig_dns_edns_do BOOLEAN,
 orig_dns_labels INT,
 svr string,
 time_micro bigint,
-anycast_server string,
-anycast_location string)
+server_ns_name string,
+server_location string)
  partitioned by (year smallint, month smallint, day smallint)
   STORED AS PARQUETFILE
   LOCATION '_HDFS_LOCATION_icmp-staging';

--- a/scripts/run/run_03_staging_to_warehouse.sh
+++ b/scripts/run/run_03_staging_to_warehouse.sh
@@ -83,7 +83,7 @@ impala-shell -i $IMPALA_NODE -V -q  "insert into $IMPALA_DNS_DWH_TABLE partition
      edns_client_subnet_asn,
      edns_client_subnet_country,
      labels,res_len,time_micro,resp_frag,proc_time,is_google,is_opendns,
-     dns_res_len,year,month,day,server
+     dns_res_len,server_ns_name, server_location, year,month,day,server
      from $IMPALA_DNS_STAGING_TABLE where year=$year and month=$month and day=$day;"
 
 if [ $? -ne 0 ]
@@ -160,7 +160,7 @@ impala-shell -i $IMPALA_NODE -V -q  "insert into $IMPALA_ICMP_DWH_TABLE partitio
       orig_dns_qtype,orig_dns_opcode,
       orig_dns_qclass,orig_dns_edns_udp,
       orig_dns_edns_version,orig_dns_edns_do,
-      orig_dns_labels,svr,time_micro,year,month,day 
+      orig_dns_labels,svr,time_micro,server_ns_name, server_location, year,month,day
      from $IMPALA_ICMP_STAGING_TABLE where year=$year and month=$month and day=$day;"
 
 if [ $? -ne 0 ]


### PR DESCRIPTION
This patch add 2 additional columns "server_ns_name" and "server_location" to the database schema. This allows to store the location of anycast-nodes. If the servername (as defined in NAMESERVERS) contains a "_", it is assumed that the part before the "_" is the anycast_server name and the part after the "_" is the location of the server f.e. r.ns.at_vie  sets "server_ns_name" to "r.ns.at" and "server_location_location" to "vie". The original svr/server fields remain untouched.