### PR TITLE
move table name declaration to config.sh

### DIFF
--- a/scripts/database/create-table-dns-queries.sql
+++ b/scripts/database/create-table-dns-queries.sql
@@ -1,7 +1,7 @@
-CREATE DATABASE IF NOT EXISTS dns;
-use dns;
+CREATE DATABASE IF NOT EXISTS _IMPALA_DNS_DWH_TABLE_DB_;
+use _IMPALA_DNS_DWH_TABLE_DB_;
 
-create external table if not exists queries (
+create external table if not exists _IMPALA_DNS_DWH_TABLE_TAB_ (
  id INT,
  unixtime BIGINT,
  time BIGINT,

--- a/scripts/database/create-table-dns-staging.sql
+++ b/scripts/database/create-table-dns-staging.sql
@@ -1,7 +1,7 @@
-CREATE DATABASE IF NOT EXISTS dns;
-use dns;
+CREATE DATABASE IF NOT EXISTS _IMPALA_DNS_STAGING_TABLE_DB_;
+use _IMPALA_DNS_STAGING_TABLE_DB_;
 
-create external table if not exists dns.staging (
+create external table if not exists _IMPALA_DNS_STAGING_TABLE_TAB_ (
  id INT,
  unixtime BIGINT,
  time BIGINT,

--- a/scripts/database/create-table-icmp-packets.sql
+++ b/scripts/database/create-table-icmp-packets.sql
@@ -1,7 +1,7 @@
-CREATE DATABASE IF NOT EXISTS icmp;
-use icmp;
+CREATE DATABASE IF NOT EXISTS _IMPALA_ICMP_DWH_TABLE_DB_;
+use _IMPALA_ICMP_DWH_TABLE_DB_;
 
-create external table if not exists icmp.packets (
+create external table if not exists _IMPALA_ICMP_DWH_TABLE_TAB_ (
 unixtime BIGINT,
 icmp_type SMALLINT,
 icmp_code SMALLINT,

--- a/scripts/database/create-table-icmp-staging.sql
+++ b/scripts/database/create-table-icmp-staging.sql
@@ -1,7 +1,7 @@
-CREATE DATABASE IF NOT EXISTS icmp;
-use icmp;
+CREATE DATABASE IF NOT EXISTS _IMPALA_ICMP_STAGING_TABLE_DB_;
+use _IMPALA_ICMP_STAGING_TABLE_DB_;
 
-create external table if not exists icmp.staging (
+create external table if not exists _IMPALA_ICMP_STAGING_TABLE_TAB_ (
 unixtime BIGINT,
 time BIGINT,
 icmp_type SMALLINT,

--- a/scripts/install/create_impala_tables.sh
+++ b/scripts/install/create_impala_tables.sh
@@ -40,9 +40,21 @@ do
     script=$(< $f)
     #replace hdfs root placeholder
     script=${script/_HDFS_LOCATION_/$HDFS_HOME}
+
+    # split the table name into db and table names and replace the placeholders
+    for TABLE in IMPALA_DNS_STAGING_TABLE IMPALA_ICMP_STAGING_TABLE IMPALA_DNS_DWH_TABLE IMPALA_ICMP_DWH_TABLE
+    do
+        IFS='.';
+        array=(${!TABLE})
+        unset IFS;
+        DB=${array[0]}
+        TAB=${array[1]}
+
+        script=${script//_${TABLE}_DB_/$DB}
+        script=${script//_${TABLE}_TAB_/$TAB}
+    done
     impala-shell -i $IMPALA_NODE -V -q  "$script"
 done
-
 
 #invalidate metadata
 impala-shell -k -i $IMPALA_NODE -V -q  "invalidate metadata;"

--- a/scripts/run/config.sh
+++ b/scripts/run/config.sh
@@ -71,3 +71,15 @@ export KEYTAB_FILE="my.keytab"
 
 #error mail recipient
 export ERROR_MAIL=""
+
+
+#HDFS directories for table files
+HDFS_DNS_STAGING="$HDFS_HOME/staging"
+HDFS_ICMP_STAGING="$HDFS_HOME/icmp-staging"
+
+# table names
+IMPALA_DNS_STAGING_TABLE="dns.staging"
+IMPALA_ICMP_STAGING_TABLE="icmp.staging"
+IMPALA_DNS_DWH_TABLE="dns.queries"
+IMPALA_ICMP_DWH_TABLE="icmp.packets"
+

--- a/scripts/run/run_02_partial_loader.sh
+++ b/scripts/run/run_02_partial_loader.sh
@@ -27,11 +27,6 @@
 
 CLASS="nl.sidn.pcap.Main"
 OUTPUT_DIR="$DATA_DIR/processed"
-HDFS_DNS_STAGING="$HDFS_HOME/staging"
-HDFS_ICMP_STAGING="$HDFS_HOME/icmp-staging"
-
-IMPALA_DNS_STAGING_TABLE="dns.staging"
-IMPALA_ICMP_STAGING_TABLE="icmp.staging"
 
 #use kerberos user "hdfs"
 IMPALA_OPTS=

--- a/scripts/run/run_03_staging_to_warehouse.sh
+++ b/scripts/run/run_03_staging_to_warehouse.sh
@@ -19,14 +19,6 @@
 # You should have received a copy of the GNU General Public License
 # along with ENTRADA.  If not, see [<http://www.gnu.org/licenses/].
 
-HDFS_DNS_STAGING="$HDFS_HOME/staging"
-HDFS_ICMP_STAGING="$HDFS_HOME/icmp-staging"
-
-IMPALA_DNS_STAGING_TABLE="dns.staging"
-IMPALA_ICMP_STAGING_TABLE="icmp.staging"
-IMPALA_DNS_DWH_TABLE="dns.queries"
-IMPALA_ICMP_DWH_TABLE="icmp.packets"
-
 IMPALA_OPTS=
 
 #use kerberos user "hdfs"

--- a/scripts/run/run_05_update_stats_staging.sh
+++ b/scripts/run/run_05_update_stats_staging.sh
@@ -25,9 +25,6 @@
 # 
 ############################################################
 
-IMPALA_DNS_STAGING_TABLE="dns.staging"
-IMPALA_ICMP_STAGING_TABLE="icmp.staging"
-
 #use kerberos user "hdfs"
 if [ -f $KEYTAB_FILE ];
 then


### PR DESCRIPTION
This patch  allows the use of multiple tables with different config files (e.g. to load a possible broken pcap file into a temporary table or load traces from different TLDs into the same hadoop cluster)

