### PR TITLE
fix handling of tld.suffix

### DIFF
--- a/pcap-to-parquet/src/main/java/nl/sidn/pcap/util/Settings.java
+++ b/pcap-to-parquet/src/main/java/nl/sidn/pcap/util/Settings.java
@@ -216,7 +216,7 @@ public class Settings {
 				parent = "." + parent;
 			}
 			
-			int labelCount = StringUtils.split(parent).length;
+			int labelCount = StringUtils.split(parent,'.').length;
 			if(StringUtils.endsWith(parent, ".")){
 				//remove last dot (will become the used tld suffix
 				tldSuffixes.add(new DomainParent(parent,StringUtils.removeEnd(parent, "."), labelCount));


### PR DESCRIPTION
the broken labelCount caused a wrong mapping from qname to domainname when using tld.suffix. 

"foo.test.co.at" has been mapped "co.co.at" instead of "test.co.at" (tld.suffix=.co.at)