### PR TITLE
fixed HDFS_LOCATION for the tables (set it in config.sh)

### DIFF
--- a/scripts/database/create-table-dns-queries.sql
+++ b/scripts/database/create-table-dns-queries.sql
@@ -58,6 +58,6 @@ create external table if not exists _IMPALA_DNS_DWH_TABLE_TAB_ (
  server_location STRING) 
  partitioned by (year INT, month INT, day INT, server string)
   STORED AS PARQUETFILE
-  LOCATION '_HDFS_LOCATION_queries';
+  LOCATION '_HDFS_DNS_QUERIES_';
   
   

--- a/scripts/database/create-table-dns-staging.sql
+++ b/scripts/database/create-table-dns-staging.sql
@@ -59,5 +59,5 @@ create external table if not exists _IMPALA_DNS_STAGING_TABLE_TAB_ (
  server_location string)
  partitioned by (year INT, month INT, day INT, server string)
   STORED AS PARQUETFILE
-  LOCATION '_HDFS_LOCATION_staging';
+  LOCATION '_HDFS_DNS_STAGING_';
 

--- a/scripts/database/create-table-icmp-packets.sql
+++ b/scripts/database/create-table-icmp-packets.sql
@@ -56,6 +56,6 @@ time_micro bigint,
 server_location string)
 partitioned by (year smallint, month smallint, day smallint)
   STORED AS PARQUETFILE
-  LOCATION '_HDFS_LOCATION_icmp';
+  LOCATION '_HDFS_ICMP_PACKETS_';
 
  

--- a/scripts/database/create-table-icmp-staging.sql
+++ b/scripts/database/create-table-icmp-staging.sql
@@ -57,6 +57,6 @@ time_micro bigint,
 server_location string)
 partitioned by (year smallint, month smallint, day smallint)
   STORED AS PARQUETFILE
-  LOCATION '_HDFS_LOCATION_icmp-staging';
+  LOCATION '_HDFS_ICMP_STAGING_';
   
  

--- a/scripts/install/create_impala_tables.sh
+++ b/scripts/install/create_impala_tables.sh
@@ -53,6 +53,10 @@ do
         script=${script//_${TABLE}_DB_/$DB}
         script=${script//_${TABLE}_TAB_/$TAB}
     done
+    for LOC in HDFS_DNS_STAGING HDFS_ICMP_STAGING HDFS_DNS_QUERIES HDFS_ICMP_PACKETS
+    do 
+        script=${script//_${LOC}_/${!LOC}}
+    done
     impala-shell -i $IMPALA_NODE -V -q  "$script"
 done
 

--- a/scripts/run/config.sh
+++ b/scripts/run/config.sh
@@ -39,7 +39,7 @@ export CONFIG_FILE="$ENTRADA_HOME/scripts/config/entrada-settings.properties"
 export IMPALA_NODE=""
 
 #hdfs locations for storing data
-export HDFS_HOME="/user/hive/entrada/"
+export HDFS_HOME="/user/hive/entrada"
 
 #input directories, subdirs must have same name as name server
 export DATA_RSYNC_DIR="/home/entrada/captures"
@@ -76,6 +76,8 @@ export ERROR_MAIL=""
 #HDFS directories for table files
 HDFS_DNS_STAGING="$HDFS_HOME/staging"
 HDFS_ICMP_STAGING="$HDFS_HOME/icmp-staging"
+HDFS_DNS_QUERIES="$HDFS_HOME/queries"
+HDFS_ICMP_PACKETS="$HDFS_HOME/icmp"
 
 # table names
 IMPALA_DNS_STAGING_TABLE="dns.staging"


### PR DESCRIPTION
this patches uses the variables defined in config.sh for the HDFS location of the tables (forgot this in my previous patch, sorry).

