### PR TITLE
Fix more kerberos opt handling

### DIFF
--- a/scripts/install/create_impala_tables.sh
+++ b/scripts/install/create_impala_tables.sh
@@ -29,7 +29,7 @@ SCRIPT_DIR=$(dirname "$0")
 echo "SCRIPT_DIR == $SCRIPT_DIR"
 source $SCRIPT_DIR/../run/config.sh
 
-if [ -f $KEYTAB_FILE ];
+if [ -f "$KEYTAB_FILE" ];
 then
    echo "initialize kerberos ticket"
    kinit $KRB_USER -k -t $KEYTAB_FILE

--- a/scripts/install/create_impala_tables.sh
+++ b/scripts/install/create_impala_tables.sh
@@ -29,10 +29,13 @@ SCRIPT_DIR=$(dirname "$0")
 echo "SCRIPT_DIR == $SCRIPT_DIR"
 source $SCRIPT_DIR/../run/config.sh
 
+IMPALA_OPTS=
+
 if [ -f "$KEYTAB_FILE" ];
 then
    echo "initialize kerberos ticket"
    kinit $KRB_USER -k -t $KEYTAB_FILE
+   IMPALA_OPTS=-k
 fi
 
 for f in $SCRIPT_DIR/../database/*.sql
@@ -57,10 +60,10 @@ do
     do 
         script=${script//_${LOC}_/${!LOC}}
     done
-    impala-shell -i $IMPALA_NODE -V -q  "$script"
+    impala-shell $IMPALA_OPTS -i $IMPALA_NODE -V -q  "$script"
 done
 
 #invalidate metadata
-impala-shell -k -i $IMPALA_NODE -V -q  "invalidate metadata;"
+impala-shell $IMPALA_OPTS -i $IMPALA_NODE -V -q  "invalidate metadata;"
 
 

--- a/scripts/run/run_02_partial_loader.sh
+++ b/scripts/run/run_02_partial_loader.sh
@@ -30,7 +30,7 @@ OUTPUT_DIR="$DATA_DIR/processed"
 
 #use kerberos user "hdfs"
 IMPALA_OPTS=
-if [ -f $KEYTAB_FILE ];
+if [ -f "$KEYTAB_FILE" ];
 then
    kinit $KRB_USER -k -t $KEYTAB_FILE
    IMPALA_OPTS=-k

--- a/scripts/run/run_05_update_stats_staging.sh
+++ b/scripts/run/run_05_update_stats_staging.sh
@@ -26,7 +26,7 @@
 ############################################################
 
 #use kerberos user "hdfs"
-if [ -f $KEYTAB_FILE ];
+if [ -f "$KEYTAB_FILE" ];
 then
    kinit $KRB_USER -k -t $KEYTAB_FILE
 fi


### PR DESCRIPTION
In PR #40  I didn't realize that  $KEYTAB_FILE being empty causes errors in other scripts as well. This PR adds similar checks in run02/run05 and create_impala_tables
 
in create_impala_tables line 60 (line 63 after the change), '-k' wasn't passed before. I'm not sure if this was a bug or intended. If this was intended then we probably should not pass '$IMPALA_OPTS' here