### PR TITLE
fixed issue #56 ECDSA RuntimeException

### DIFF
--- a/dnslib4java/src/main/java/nl/sidn/dnslib/message/records/dnssec/DNSKEYResourceRecord.java
+++ b/dnslib4java/src/main/java/nl/sidn/dnslib/message/records/dnssec/DNSKEYResourceRecord.java
@@ -82,7 +82,7 @@ public class DNSKEYResourceRecord extends AbstractResourceRecord {
 		keydata = new byte[keysize];
 		buffer.readBytes(keydata);
 	
-		publicKey = KeyUtil.createRSAPublicKey(keydata);
+		publicKey = KeyUtil.createPublicKey(keydata, algorithm);
 		
 		keytag =  KeyUtil.createKeyTag(rdata, algorithm);
 		


### PR DESCRIPTION
Tried to fix the ECDSA issue. Actually, to clarify: the RuntimeException title was maybe slightly confusing, since the RuntimeException got catched within the code and just resulted in a log entry saying something about 'Error creating public key'. I ran the code on 1 pcap file and everything seemed to work fine. There where slightly more parsed packets than in the original version, since the ones having ECDSA DNS keys did not get ignored.