### PR TITLE
Fix ArrayIndexOutOfBoundsException in NetworkData

### DIFF
--- a/dnslib4java/src/main/java/nl/sidn/dnslib/message/util/NetworkData.java
+++ b/dnslib4java/src/main/java/nl/sidn/dnslib/message/util/NetworkData.java
@@ -55,7 +55,12 @@ public class NetworkData {
 	}
 	
 	public NetworkData(byte[] data){
-		this.buf = data;
+		if (data.length % 2 == 1) {
+			this.buf = Arrays.copyOf(data, data.length + 1);
+		}
+		else {
+			this.buf = data;
+		}
 		index = 0;
 	}
 	


### PR DESCRIPTION
Fixes #72 by padding the buffer array to an even number of bytes, if necessary.

[This anonymized PCAP](https://github.com/SIDN/entrada/files/2129024/BadPacket-Anon.zip) contains a single packet that will cause an exception to be thrown.

