### PR TITLE
IP byte[] representation

### DIFF
--- a/pcap-to-parquet/src/main/java/nl/sidn/pcap/util/GeoLookupUtil.java
+++ b/pcap-to-parquet/src/main/java/nl/sidn/pcap/util/GeoLookupUtil.java
@@ -30,7 +30,6 @@ import org.slf4j.LoggerFactory;
 import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 
 /**
  * Utility class to lookup IP adress information such as country and asn. Uses the maxmind database
@@ -63,29 +62,20 @@ public class GeoLookupUtil {
   }
 
   public String lookupCountry(String ip) {
+    InetAddress inetAddr;
     try {
-      return lookupCountry(InetAddress.getByName(ip));
-    } catch (UnknownHostException e) {
+      inetAddr = InetAddresses.forString(ip);
+    } catch (Exception e) {
       if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("No country found for: " + ip);
+        LOGGER.debug("Invalid IP address: " + ip);
       }
       return null;
     }
-  }
-
-  public String lookupCountry(byte[] ip) {
-    try {
-      return lookupCountry(InetAddress.getByAddress(ip));
-    } catch (UnknownHostException e) {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("No country found for: " + ip);
-      }
-      return null;
-    }
+    return lookupCountry(inetAddr);
   }
 
   public String lookupCountry(InetAddress addr) {
-    CountryResponse response = null;
+    CountryResponse response;
 
     try {
       response = geoReader.country(addr);
@@ -96,19 +86,6 @@ public class GeoLookupUtil {
       return null;
     }
     return response.getCountry().getIsoCode();
-  }
-
-  public String lookupASN(byte[] ip) {
-    InetAddress inetAddr;
-    try {
-      inetAddr = InetAddress.getByAddress(ip);
-    } catch (Exception e) {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("Invalid IP address: " + ip);
-      }
-      return null;
-    }
-    return lookupASN(inetAddr);
   }
 
   public String lookupASN(InetAddress ip) {

--- a/pcap-to-parquet/src/main/java/nl/sidn/pcap/util/GeoLookupUtil.java
+++ b/pcap-to-parquet/src/main/java/nl/sidn/pcap/util/GeoLookupUtil.java
@@ -19,18 +19,18 @@
  */
 package nl.sidn.pcap.util;
 
-import java.io.File;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import com.google.common.net.InetAddresses;
 import com.maxmind.db.CHMCache;
 import com.maxmind.geoip2.DatabaseReader;
 import com.maxmind.geoip2.model.AsnResponse;
-import com.maxmind.geoip2.model.CityResponse;
 import com.maxmind.geoip2.model.CountryResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 
 /**
  * Utility class to lookup IP adress information such as country and asn. Uses the maxmind database
@@ -98,25 +98,10 @@ public class GeoLookupUtil {
     return response.getCountry().getIsoCode();
   }
 
-  public String lookupCity(String ip) {
-    CityResponse response = null;
-
-    try {
-      response = geoReader.city(InetAddress.getByName(ip));
-    } catch (Exception e) {
-      if (LOGGER.isDebugEnabled()) {
-        LOGGER.debug("No city found for: " + ip);
-      }
-      return null;
-    }
-
-    return response.getCity().getName();
-  }
-
   public String lookupASN(byte[] ip) {
     InetAddress inetAddr;
     try {
-      inetAddr = InetAddresses.fromLittleEndianByteArray(ip);
+      inetAddr = InetAddress.getByAddress(ip);
     } catch (Exception e) {
       if (LOGGER.isDebugEnabled()) {
         LOGGER.debug("Invalid IP address: " + ip);

--- a/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
+++ b/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
@@ -19,12 +19,16 @@
  */
 package nl.sidn.pcap.util;
 
-import java.net.InetAddress;
-import java.net.UnknownHostException;
+import com.google.common.collect.Lists;
+import com.google.common.net.InetAddresses;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import com.google.common.net.InetAddresses;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import static org.junit.Assert.assertEquals;
 
 public class GeoLookupUtilTest {
 
@@ -40,33 +44,117 @@ public class GeoLookupUtilTest {
   }
 
   @Test
-  public void testAsnLookupIpv4() throws UnknownHostException {
+  public void testAsnLookupIpv4() {
     InetAddress addr = InetAddresses.forString("94.198.159.1");
     String asn = geo.lookupASN(addr);
     Assert.assertEquals("1140", asn);
   }
 
   @Test
-  public void testAsnLookupIpv6() throws UnknownHostException {
+  public void testAsnLookupIpv6() {
     InetAddress addr = InetAddresses.forString("2a00:d78::147:94:198:152");
     String asn = geo.lookupASN(addr);
     Assert.assertEquals("1140", asn);
   }
 
   @Test
-  public void testGeoLookupIpv4() throws UnknownHostException {
+  public void testGeoLookupIpv4() {
     InetAddress addr = InetAddresses.forString("94.198.159.1");
     String country = geo.lookupCountry(addr);
     Assert.assertEquals("NL", country);
   }
 
   @Test
-  public void testGeoLookupIpv6() throws UnknownHostException {
+  public void testGeoLookupIpv6() {
     InetAddress addr = InetAddresses.forString("2a00:d78::147:94:198:152");
     String country = geo.lookupCountry(addr);
     Assert.assertEquals("NL", country);
   }
 
+  @Test
+  public void lookup() {
+    String ip = "81.164.126.240";
+    assertEquals("BE", geo.lookupCountry(ip));
+    assertEquals("6848", geo.lookupASN(ip));
 
+    ip = "8.8.8.8";
+    assertEquals("US", geo.lookupCountry(ip));
+    assertEquals("15169", geo.lookupASN(ip));
+
+    ip = "212.114.98.233";
+    assertEquals("NL", geo.lookupCountry(ip));
+    assertEquals("12859", geo.lookupASN(ip));
+
+    ip = "74.80.115.0";
+    assertEquals("CN", geo.lookupCountry(ip));
+    assertEquals("715", geo.lookupASN(ip));
+
+    ip = "74.80.89.0";
+    assertEquals("DE", geo.lookupCountry(ip));
+    assertEquals("715", geo.lookupASN(ip));
+
+    ip = "2620:0171:00F7:0000::";
+    assertEquals("ZA", geo.lookupCountry(ip));
+    assertEquals("42", geo.lookupASN(ip));
+
+    ip = "2001:0500:0015:0600::";
+    assertEquals("US", geo.lookupCountry(ip));
+    assertEquals("715", geo.lookupASN(ip));
+  }
+
+
+  @Test
+  public void lookupBytes() throws UnknownHostException {
+    InetAddress address = InetAddresses.forString("74.80.89.0");
+
+    assertEquals("DE", geo.lookupCountry(address));
+    assertEquals("715", geo.lookupASN(address));
+    byte[] bytes = address.getAddress();
+    assertEquals("DE", geo.lookupCountry(bytes));
+    assertEquals("715", geo.lookupASN(bytes));
+
+    // Both should be equivalent
+    address = InetAddress.getByName("74.80.89.0");
+
+    assertEquals("DE", geo.lookupCountry(address));
+    assertEquals("715", geo.lookupASN(address));
+    bytes = address.getAddress();
+    assertEquals("DE", geo.lookupCountry(bytes));
+    assertEquals("715", geo.lookupASN(bytes));
+  }
+
+  @Test
+  public void testLookupAsn() {
+    for (String ip : Lists.newArrayList("185.20.63.0", "2001:0500:0015:0600::")) {
+      InetAddress address = InetAddresses.forString(ip);
+      byte[] bytes = address.getAddress();
+
+      String byString = geo.lookupASN(ip);
+      String byBytes = geo.lookupASN(bytes);
+      String byAddress = geo.lookupASN(address);
+
+      System.out.println("byString = " + byString);
+      System.out.println("byBytes = " + byBytes);
+      System.out.println("byAddress = " + byAddress);
+
+      assertEquals(byAddress, byString);
+      assertEquals(byAddress, byBytes);
+    }
+  }
+
+  @Test
+  public void testLookupCountry() {
+    String ip = "185.20.63.0";
+    InetAddress address = InetAddresses.forString(ip);
+    byte[] bytes = address.getAddress();
+
+    String byString = geo.lookupCountry(ip);
+    String byBytes = geo.lookupCountry(bytes);
+    String byAddress = geo.lookupCountry(address);
+
+    System.out.println("byString = " + byString);
+    System.out.println("byBytes = " + byBytes);
+    System.out.println("byAddress = " + byAddress);
+  }
 
 }

--- a/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
+++ b/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
@@ -48,6 +48,10 @@ public class GeoLookupUtilTest {
     InetAddress addr = InetAddresses.forString("94.198.159.1");
     String asn = geo.lookupASN(addr);
     Assert.assertEquals("1140", asn);
+
+    byte[] addrByte = addr.getAddress();
+    asn = geo.lookupASN(addrByte);
+    Assert.assertEquals("1140", asn);
   }
 
   @Test
@@ -61,6 +65,10 @@ public class GeoLookupUtilTest {
   public void testGeoLookupIpv4() {
     InetAddress addr = InetAddresses.forString("94.198.159.1");
     String country = geo.lookupCountry(addr);
+    Assert.assertEquals("NL", country);
+
+    byte[] addrByte = addr.getAddress();
+    country = geo.lookupCountry(addr);
     Assert.assertEquals("NL", country);
   }
 

--- a/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
+++ b/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
@@ -48,10 +48,6 @@ public class GeoLookupUtilTest {
     InetAddress addr = InetAddresses.forString("94.198.159.1");
     String asn = geo.lookupASN(addr);
     Assert.assertEquals("1140", asn);
-
-    byte[] addrByte = addr.getAddress();
-    asn = geo.lookupASN(addrByte);
-    Assert.assertEquals("1140", asn);
   }
 
   @Test
@@ -117,36 +113,26 @@ public class GeoLookupUtilTest {
 
     assertEquals("DE", geo.lookupCountry(address));
     assertEquals("715", geo.lookupASN(address));
-    byte[] bytes = address.getAddress();
-    assertEquals("DE", geo.lookupCountry(bytes));
-    assertEquals("715", geo.lookupASN(bytes));
 
     // Both should be equivalent
     address = InetAddress.getByName("74.80.89.0");
 
     assertEquals("DE", geo.lookupCountry(address));
     assertEquals("715", geo.lookupASN(address));
-    bytes = address.getAddress();
-    assertEquals("DE", geo.lookupCountry(bytes));
-    assertEquals("715", geo.lookupASN(bytes));
   }
 
   @Test
   public void testLookupAsn() {
     for (String ip : Lists.newArrayList("185.20.63.0", "2001:0500:0015:0600::")) {
       InetAddress address = InetAddresses.forString(ip);
-      byte[] bytes = address.getAddress();
 
       String byString = geo.lookupASN(ip);
-      String byBytes = geo.lookupASN(bytes);
       String byAddress = geo.lookupASN(address);
 
       System.out.println("byString = " + byString);
-      System.out.println("byBytes = " + byBytes);
       System.out.println("byAddress = " + byAddress);
 
       assertEquals(byAddress, byString);
-      assertEquals(byAddress, byBytes);
     }
   }
 
@@ -154,15 +140,14 @@ public class GeoLookupUtilTest {
   public void testLookupCountry() {
     String ip = "185.20.63.0";
     InetAddress address = InetAddresses.forString(ip);
-    byte[] bytes = address.getAddress();
 
     String byString = geo.lookupCountry(ip);
-    String byBytes = geo.lookupCountry(bytes);
     String byAddress = geo.lookupCountry(address);
 
     System.out.println("byString = " + byString);
-    System.out.println("byBytes = " + byBytes);
     System.out.println("byAddress = " + byAddress);
+
+    assertEquals(byAddress, byString);
   }
 
 }


### PR DESCRIPTION
Hola SIDN,

I am not sure this is a bug and I wanted your input on this one.

There is this lookupASN function in GeoLookupUtil returning the ASN number given a certain IP, using the Maxmind DB. This function is overloaded with different representation of an IP, including a bit array representation.
Ultimately, the IP is is transformed to a InetAddress using Guava. For the byte array representation, you considered the bit representation being little endian for IP. (see InetAddresses.fromLittleEndianByteArray(ip))
I did not investigate until the pcap is read and transformed to an object and if the bit representation was big or little endian; However i see that InetAddress returns a big endian representation of the IP and so at the end, by reading little endian and return big endian you might not match the original IP, right ?

Is my explanation and reflexion path make sense ?

I think it would be good to not allow bit array in function to avoid confusion. (that's what the third commit is about).

Feel free to chose what is interesting in my commits. I am also available for a quick call.

We would like to use your library for a similar project without copy/paste to much of your code in ours, and so we would continue making pull request if it is ok for you.

Thanks for sharing your code
Quentin