### PR TITLE
avoid hard-coded path in GeoLookupUtilTest

### DIFF
--- a/pcap-to-parquet/pom.xml
+++ b/pcap-to-parquet/pom.xml
@@ -145,4 +145,8 @@
 
 	</dependencies>
 
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
 </project>

--- a/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
+++ b/pcap-to-parquet/src/test/java/nl/sidn/pcap/util/GeoLookupUtilTest.java
@@ -36,10 +36,13 @@ public class GeoLookupUtilTest {
 
   @Before
   public void setup() {
+    String userHome = System.getProperty("user.home");
+    String path = userHome + "/sidn/development/tmp/entrada/";
+    // make sure you have a maxmind folder in $HOME/sidn/development/tmp/entrada/ with the correct .mmdb files
+    System.out.println("path = " + path);
     ClassLoader classLoader = getClass().getClassLoader();
     Settings.setPath(classLoader.getResource("test-settings.properties").getFile());
-    Settings.getInstance().setSetting(Settings.STATE_LOCATION,
-        "/Users/maartenwullink/sidn/development/tmp/entrada/");
+    Settings.getInstance().setSetting(Settings.STATE_LOCATION, path);
     geo = new GeoLookupUtil();
   }
 


### PR DESCRIPTION
This way everyone can run the "mvn package" without changing the code.
(after downloading maxmind files in $HOME/sidn/development/tmp/entrada/maxmind) 