### PR TITLE
make S3 bucket and lifecycle rule management conditional

### DIFF
--- a/src/main/java/nl/sidnlabs/entrada/initialize/AmazonInitializer.java
+++ b/src/main/java/nl/sidnlabs/entrada/initialize/AmazonInitializer.java
@@ -45,10 +45,11 @@ public class AmazonInitializer extends AbstractInitializer {
   @Value("${entrada.archive.files.max.age}")
   private int archiveExpiration;
 
-
   @Value("${aws.bucket.rules.url}")
   private String bucketRules;
 
+  @Value("${aws.bucket.manage}")
+  private boolean manageBucket;
 
   private AmazonS3 amazonS3;
   private FileManager fileManager;
@@ -78,6 +79,11 @@ public class AmazonInitializer extends AbstractInitializer {
       throw new ApplicationException("\"" + bucket
           + "\" is not a valid S3 bucket name, for bucket restrictions and limitations, see: "
           + bucketRules);
+    }
+
+    // only create bucket and lifecycle rules if we are managing the bucket
+    if (!manageBucket) {
+      return true;
     }
 
     if (!amazonS3.doesBucketExistV2(bucket)) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -241,6 +241,9 @@ aws.upload.upload.storage-class=STANDARD_IA
 # storage class for pcap files uploaded to S3 bucket
 aws.upload.archive.storage-class=STANDARD_IA
 
+# manage S3 bucket and associated lifecycle rules from entrada code
+aws.bucket.manage=true
+
 aws.bucket.rules.url=https://docs.aws.amazon.com/AmazonS3/latest/dev/BucketRestrictions.html
 
 # Athena


### PR DESCRIPTION
Fe, we don't give the app runtime rights to create such resources; but manage infrastructure-as-code at deploy time