### PR TITLE
differentiate table name from table type, since it is configurable

### DIFF
--- a/src/main/java/nl/sidnlabs/entrada/engine/AbstractQueryEngine.java
+++ b/src/main/java/nl/sidnlabs/entrada/engine/AbstractQueryEngine.java
@@ -32,6 +32,12 @@ public abstract class AbstractQueryEngine implements QueryEngine {
   @Value("${entrada.database.name}")
   private String database;
 
+  @Value("${entrada.database.table.dns}")
+  protected String tableDns;
+
+  @Value("${entrada.database.table.icmp}")
+  protected String tableIcmp;
+
   protected JdbcTemplate jdbcTemplate;
   protected FileManager fileManager;
   private String scriptPrefix;
@@ -113,7 +119,14 @@ public abstract class AbstractQueryEngine implements QueryEngine {
   private Map<String, Object> createValueMap(TablePartition p) {
     Map<String, Object> values = new HashMap<>();
     values.put("DATABASE_NAME", database);
-    values.put("TABLE_NAME", p.getTable());
+    switch(p.getTable()) {
+      case "dns":
+        values.put("TABLE_NAME", tableDns);
+        break;
+      case "icmp":
+        values.put("TABLE_NAME", tableIcmp);
+        break;
+    }
     values.put("TABLE_LOC", tableLocation(p));
     values.put("YEAR", p.getYear());
     values.put("MONTH", p.getMonth());
@@ -182,7 +195,7 @@ public abstract class AbstractQueryEngine implements QueryEngine {
 
 
   @Override
-  public boolean addPartition(String table, Set<Partition> partitions) {
+  public boolean addPartition(String type, String table, Set<Partition> partitions) {
 
     Map<String, Object> values = new HashMap<>();
     values.put("DATABASE_NAME", database);
@@ -197,7 +210,7 @@ public abstract class AbstractQueryEngine implements QueryEngine {
       values.put("SERVER", p.getServer());
 
       String sql = TemplateUtil
-          .template(new ClassPathResource("/sql/create-partition-" + table + ".sql", getClass()),
+          .template(new ClassPathResource("/sql/create-partition-" + type + ".sql", getClass()),
               values);
 
       log.info("Create partition, sql: {}", sql);

--- a/src/main/java/nl/sidnlabs/entrada/engine/LocalQueryEngine.java
+++ b/src/main/java/nl/sidnlabs/entrada/engine/LocalQueryEngine.java
@@ -11,7 +11,7 @@ import nl.sidnlabs.entrada.model.jpa.TablePartition;
 public class LocalQueryEngine implements QueryEngine {
 
   @Override
-  public boolean addPartition(String table, Set<Partition> partitions) {
+  public boolean addPartition(String type, String table, Set<Partition> partitions) {
     // do nothing
     return true;
   }

--- a/src/main/java/nl/sidnlabs/entrada/engine/QueryEngine.java
+++ b/src/main/java/nl/sidnlabs/entrada/engine/QueryEngine.java
@@ -8,7 +8,7 @@ public interface QueryEngine {
 
   boolean execute(String sql);
 
-  boolean addPartition(String table, Set<Partition> partitions);
+  boolean addPartition(String type, String table, Set<Partition> partitions);
 
   boolean postAddPartition(String table, Partition p);
 

--- a/src/main/java/nl/sidnlabs/entrada/service/UploadService.java
+++ b/src/main/java/nl/sidnlabs/entrada/service/UploadService.java
@@ -66,7 +66,7 @@ public class UploadService {
          * missing database partition(s)
          */
 
-        queryEngine.addPartition(tableNameDns, partitions.get("dns"));
+        queryEngine.addPartition("dns", tableNameDns, partitions.get("dns"));
 
         // only delete work loc when upload was ok, if upload failed
         // it will be retried next time
@@ -85,7 +85,7 @@ public class UploadService {
         String dstLocation = FileUtil.appendPath(outputLocation, tableNameIcmp);
         if (fmOutput.upload(location, dstLocation, false)) {
 
-          queryEngine.addPartition(tableNameIcmp, partitions.get("icmp"));
+          queryEngine.addPartition("icmp", tableNameIcmp, partitions.get("icmp"));
 
           log.info("Delete work location: {}", location);
           fmInput.rmdir(location);


### PR DESCRIPTION
it was assumed on various places that the DNS table was called "dns"; and icmp table "icmp"; while they are configurable.
Bumped into it by accident since our pcap-to-athena fork used a different table name