### PR TITLE
pub resolver arrays got appended every time creating a leak

### DIFF
--- a/src/main/java/nl/sidnlabs/entrada/enrich/resolver/AbstractResolverCheck.java
+++ b/src/main/java/nl/sidnlabs/entrada/enrich/resolver/AbstractResolverCheck.java
@@ -67,6 +67,8 @@ public abstract class AbstractResolverCheck implements DnsResolverCheck {
     // load new subnets from source
     List<String> subnets = fetch();
     if (!subnets.isEmpty()) {
+      matchers4.clear();
+      matchers6.clear();
       // create internal bitsubnets for camparissions
       subnets
           .stream()
@@ -125,6 +127,8 @@ public abstract class AbstractResolverCheck implements DnsResolverCheck {
       log.error("Error while reading file: {}", file, e);
       return false;
     }
+    matchers4.clear();
+    matchers6.clear();
 
     lines
         .stream()


### PR DESCRIPTION
* Lazy fix for now, clear the array
* Perhaps only-add to array if new? (but what if subnets get removed from source, they should also be removed from array .. although those sources are probably not that likely to have such changes)