### PR TITLE
clear metriccache if graphite export is disabled, to avoid OOM

### DIFF
--- a/src/main/java/nl/sidnlabs/entrada/load/PacketProcessor.java
+++ b/src/main/java/nl/sidnlabs/entrada/load/PacketProcessor.java
@@ -502,6 +502,10 @@ public class PacketProcessor {
       // always send historical stats to monitoring
       if (metrics) {
         metricManager.persistState(stateManager);
+      } else {
+        // TODO: don't collect metrics if graphite is disabled, use micrometer abstraction directly perhaps, to make it compatible with other metric backends?
+        //  for now clear stats collection if graphite export is disabled, otherwise app goes OOM after a while
+        metricManager.clear();
       }
 
     } catch (Exception e) {

--- a/src/main/java/nl/sidnlabs/entrada/metric/HistoricalMetricManager.java
+++ b/src/main/java/nl/sidnlabs/entrada/metric/HistoricalMetricManager.java
@@ -175,6 +175,10 @@ public class HistoricalMetricManager {
     return true;
   }
 
+  public void clear() {
+    metricCache.clear();
+  }
+
   private void trunc(TreeMap<Long, Metric> metricValues) {
     int max = metricValues.size() - FLUSH_TIMESTAMP_WAIT;
     if (max < 1) {


### PR DESCRIPTION
With graphite export enabled it will go over the metrics, push them and truncate the cache afterwards.
However, if you disable graphite export the send/flush is conditional; but collecting metrics isn't, nor is clearing them from time to time. This creates an OOM after a while.