### PR TITLE
default impala.ssl value changed

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -289,7 +289,7 @@ impala.log.level=1
 impala.log.path=${entrada.location.log}/impala-logs/
 
 # use ssl, make sure the root CA is in java cacerts file
-impala.ssl=1
+impala.ssl=0
 
 # additional url options
 impala.url.additional


### PR DESCRIPTION
Fix for the "impala timeout error" when user update ENTRADA from older versions and isn't using SSL. On the ENTRADA website, the default value for IMPALA_SSL is 0.