### PR TITLE
fixes #168: if more than 1000 files were present under S3 prefix it g…

### DIFF
--- a/src/main/java/nl/sidnlabs/entrada/file/S3FileManagerImpl.java
+++ b/src/main/java/nl/sidnlabs/entrada/file/S3FileManagerImpl.java
@@ -97,6 +97,7 @@ public class S3FileManagerImpl implements FileManager {
       do {
         listing = amazonS3.listObjectsV2(lor);
         listing.getObjectSummaries().stream().forEach(os -> files.add(os.getKey()));
+        lor.setContinuationToken(listing.getNextContinuationToken());
       } while (listing.isTruncated());
 
     } catch (Exception e) {


### PR DESCRIPTION
…ot caught in a loop without moving the iterator