### PR TITLE
fixes #172: Fix hadoop calls for non-existent users

### DIFF
--- a/src/main/java/nl/sidnlabs/entrada/parquet/ParquetPartition.java
+++ b/src/main/java/nl/sidnlabs/entrada/parquet/ParquetPartition.java
@@ -8,6 +8,7 @@ import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.parquet.avro.AvroParquetWriter;
 import org.apache.parquet.column.ParquetProperties.WriterVersion;
 import org.apache.parquet.hadoop.ParquetWriter;
@@ -17,6 +18,7 @@ import lombok.Setter;
 import lombok.experimental.NonFinal;
 import lombok.extern.log4j.Log4j2;
 import nl.sidnlabs.entrada.exception.ApplicationException;
+import org.springframework.beans.factory.annotation.Value;
 
 @Log4j2
 @Getter
@@ -25,6 +27,9 @@ public class ParquetPartition<T> {
 
   private static Configuration conf = new Configuration();
 
+  @Value("${hadoop.login.user}")
+  private String loginUser;
+
   private ParquetWriter<T> writer;
   private String filename;
   @NonFinal
@@ -32,6 +37,10 @@ public class ParquetPartition<T> {
   private Path currentFile;
 
   public ParquetPartition(String partition, Schema schema, int rowgroupsize, int pageRowLimit) {
+
+    if (loginUser != null) {
+      UserGroupInformation.setLoginUser(UserGroupInformation.createRemoteUser(loginUser));
+    }
 
     long start = System.currentTimeMillis();
 

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -338,6 +338,10 @@ hdfs.username=hdfs
 hdfs.data.owner=impala
 hdfs.data.group=hive
 
+# login user to use for hadoop calls, by default the UID gets looked up in /etc/passwd.
+# This gives a nullpointer if it's not present, only overridden when value is not null
+hadoop.login.user=
+
 impala.log.level=3
 impala.log.path=${entrada.location.log}/impala-logs/
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -333,6 +333,10 @@ hdfs.username=hdfs
 hdfs.data.owner=impala
 hdfs.data.group=hive
 
+# login user to use for hadoop calls, by default the UID gets looked up in /etc/passwd.
+# This gives a nullpointer if it's not present, only overridden when value is not null
+hadoop.login.user=
+
 impala.log.level=0
 impala.log.path=${entrada.location.log}/impala-logs/
 


### PR DESCRIPTION
* if the user you're running as doesn't exist in passwd/nss the hadoop calls failed with "Caused by: javax.security.auth.login.LoginException: java.lang.NullPointerException: invalid null input: name"