### PR TITLE
Fixes #191: add ability to auto-discover nameservers

### DIFF
--- a/src/main/java/nl/sidnlabs/entrada/file/FileManager.java
+++ b/src/main/java/nl/sidnlabs/entrada/file/FileManager.java
@@ -22,6 +22,8 @@ public interface FileManager {
 
   List<String> files(String location, boolean recursive, String... filter);
 
+  List<String> folders(String location);
+
   Optional<InputStream> open(String location);
 
   /**

--- a/src/main/java/nl/sidnlabs/entrada/file/HDFSFileManagerImpl.java
+++ b/src/main/java/nl/sidnlabs/entrada/file/HDFSFileManagerImpl.java
@@ -141,6 +141,12 @@ public class HDFSFileManagerImpl implements FileManager {
     return Collections.emptyList();
   }
 
+  @Override
+  public List<String> folders(String dir) {
+// TODO: see how to list first level directories on hadoop; since we don't run on hadoop we can't test it
+    return Collections.emptyList();
+  }
+
   private boolean checkFilter(String file, List<String> filters) {
     if (filters.isEmpty()) {
       return true;

--- a/src/main/java/nl/sidnlabs/entrada/file/LocalFileManagerImpl.java
+++ b/src/main/java/nl/sidnlabs/entrada/file/LocalFileManagerImpl.java
@@ -70,6 +70,22 @@ public class LocalFileManagerImpl implements FileManager {
         .collect(Collectors.toList());
   }
 
+  @Override
+  public List<String> folders(String dir) {
+
+    File fDir = new File(dir);
+    if (!fDir.isDirectory()) {
+      log.error("{} is not a valid directory", dir);
+      return Collections.emptyList();
+    }
+
+    return Arrays
+            .stream(fDir.listFiles())
+            .filter(File::isDirectory)
+            .map(File::getName)
+            .collect(Collectors.toList());
+  }
+
   private boolean checkFilter(String file, List<String> filters) {
     if (filters.isEmpty()) {
       return true;

--- a/src/main/java/nl/sidnlabs/entrada/file/S3FileManagerImpl.java
+++ b/src/main/java/nl/sidnlabs/entrada/file/S3FileManagerImpl.java
@@ -112,6 +112,32 @@ public class S3FileManagerImpl implements FileManager {
         .collect(Collectors.toList());
   }
 
+  @Override
+  public List<String> folders(String location) {
+    List<String> folders = new ArrayList<>();
+
+    Optional<S3Details> details = S3Details.from(location);
+    if (!details.isPresent()) {
+      return folders;
+    }
+
+    ListObjectsV2Request lor = new ListObjectsV2Request()
+            .withBucketName(details.get().getBucket())
+            .withPrefix(details.get().getKey())
+            .withDelimiter("/");
+
+    ListObjectsV2Result listing = amazonS3.listObjectsV2(lor);
+    listing.getCommonPrefixes().stream().forEach(os -> folders.add(
+            StringUtils.replace(
+                    StringUtils.removeEnd(os, "/"),
+                    details.get().getKey(),
+                    ""
+            )
+    ));
+
+    return folders;
+  }
+
   private boolean checkFilter(String file, List<String> filters) {
     if (filters.isEmpty()) {
       return true;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -152,6 +152,7 @@ entrada.engine=local
 # List of name server sub-directories in the inout directory
 # each server sub-directories can have format <ns>_<anycast_site>
 # the ns and anycast_site parts will be extracted and save with the DNS data
+# if set to auto it will process all folders in directory and deduce server name from folder name
 entrada.nameservers=
 # name of the entrada database and tables that should be created 
 entrada.database.name=entrada


### PR DESCRIPTION
Adds an auto-discover option for nameservers.
Caveat, the method hasn't been implemented for Hadoop code path since we didn't have access to one.
But this has been very useful for us, so probably not hard to get working as well for Hadoop if deemed useful for others