### PR TITLE
JVM proxy settings are ignored

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -431,7 +431,7 @@
 				</executions>
 				<configuration>
 					<repository>docker.io/sidnlabs/entrada</repository>
-					<tag>${project.version}</tag>
+					<tag>155.153</tag>
 					<useMavenSettingsForAuth>true</useMavenSettingsForAuth>
 					<buildArgs>
 						<JAR_FILE>${project.build.finalName}.jar</JAR_FILE>

--- a/src/main/java/nl/sidnlabs/entrada/enrich/resolver/CloudFlareResolverCheck.java
+++ b/src/main/java/nl/sidnlabs/entrada/enrich/resolver/CloudFlareResolverCheck.java
@@ -60,7 +60,7 @@ public final class CloudFlareResolverCheck extends AbstractResolverCheck {
         .setConnectionRequestTimeout(timeoutInMillis)
         .setSocketTimeout(timeoutInMillis)
         .build();
-    CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+    CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(config).useSystemProperties().build();
 
     List<String> subnets = new ArrayList<>();
     process(client, urlV4, subnets);

--- a/src/main/java/nl/sidnlabs/entrada/enrich/resolver/OpenDNSResolverCheck.java
+++ b/src/main/java/nl/sidnlabs/entrada/enrich/resolver/OpenDNSResolverCheck.java
@@ -69,7 +69,7 @@ public final class OpenDNSResolverCheck extends AbstractResolverCheck {
         .setConnectionRequestTimeout(timeout * 1000)
         .setSocketTimeout(timeout * 1000)
         .build();
-    CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
+    CloseableHttpClient client = HttpClientBuilder.create().setDefaultRequestConfig(config).useSystemProperties().build();
 
     try {
       HttpGet get = new HttpGet(url);

--- a/src/main/java/nl/sidnlabs/entrada/util/DownloadUtil.java
+++ b/src/main/java/nl/sidnlabs/entrada/util/DownloadUtil.java
@@ -19,7 +19,7 @@ public class DownloadUtil {
     log.info("GET URL: " + logUrl);
 
     CloseableHttpClient client =
-        HttpClientBuilder.create().setDefaultRequestConfig(createConfig(timeout * 1000)).build();
+        HttpClientBuilder.create().setDefaultRequestConfig(createConfig(timeout * 1000)).useSystemProperties().build();
     try {
       HttpResponse response = client.execute(new HttpGet(url));
 


### PR DESCRIPTION
JVM proxy settings (`http.proxyHost`, `http.proxyPort`, `https.proxyHost`, `https.proxyPort`) are ignored when using `RequestConfig.custom()`. Such fetches completely ignore http(s) proxy.

This behaviour was observed in 3 files:
  - /src/main/java/nl/sidnlabs/entrada/enrich/resolver/CloudFlareResolverCheck.java
  - /src/main/java/nl/sidnlabs/entrada/enrich/resolver/OpenDNSResolverCheck.java
  - /src/main/java/nl/sidnlabs/entrada/util/DownloadUtil.java

System properties can be enabled using the following changes and adding options to JAVA_OPTS.